### PR TITLE
Switch文直下にRoute以外のコンポーネントがあったので削除

### DIFF
--- a/app/frontend/js/pages/Index.tsx
+++ b/app/frontend/js/pages/Index.tsx
@@ -10,7 +10,6 @@ const Index: React.FC = () => {
 
   return (
     <Switch>
-      <div className="test">testです</div>
       <Route exact path="/">
         <List />
       </Route>


### PR DESCRIPTION
## 概要
・React-Routerのエラー修正
Switchの直下は Routeか Redirectでなければならないので修正

## 参考URL
https://chaika.hatenablog.com/entry/2020/04/21/124500